### PR TITLE
Feat/103/mocks

### DIFF
--- a/crates/scouter_client/src/lib.rs
+++ b/crates/scouter_client/src/lib.rs
@@ -43,7 +43,7 @@ pub use scouter_drift::{
 };
 pub use scouter_events::error::PyEventError;
 pub use scouter_events::producer::{
-    kafka::KafkaConfig, rabbitmq::RabbitMQConfig, redis::RedisConfig,
+    kafka::KafkaConfig, mock::MockConfig, rabbitmq::RabbitMQConfig, redis::RedisConfig,
 };
 pub use scouter_events::queue::{
     custom::CustomMetricFeatureQueue, psi::PsiFeatureQueue, spc::SpcFeatureQueue, QueueBus,

--- a/crates/scouter_events/src/error.rs
+++ b/crates/scouter_events/src/error.rs
@@ -181,6 +181,9 @@ pub enum PyEventError {
 
     #[error("Failed to shutdown queue")]
     ShutdownQueueError(#[source] pyo3::PyErr),
+
+    #[error("Failed to convert TransportConfig type to py object: {0}")]
+    ConvertToPyError(#[source] pyo3::PyErr),
 }
 impl From<PyEventError> for PyErr {
     fn from(err: PyEventError) -> PyErr {

--- a/crates/scouter_events/src/producer/mock/mod.rs
+++ b/crates/scouter_events/src/producer/mock/mod.rs
@@ -1,0 +1,5 @@
+pub mod producer;
+pub mod types;
+
+pub use producer::MockProducer;
+pub use types::MockConfig;

--- a/crates/scouter_events/src/producer/mock/producer.rs
+++ b/crates/scouter_events/src/producer/mock/producer.rs
@@ -1,0 +1,22 @@
+use crate::error::EventError;
+use crate::producer::mock::MockConfig;
+use scouter_types::ServerRecords;
+use tracing::info;
+
+#[derive(Debug, Clone)]
+pub struct MockProducer {}
+impl MockProducer {
+    pub async fn new(_config: MockConfig) -> Result<Self, EventError> {
+        Ok(MockProducer {})
+    }
+
+    pub async fn publish(&mut self, message: ServerRecords) -> Result<(), EventError> {
+        // Mock implementation, just log the message
+        info!("MockProducer publishing message: {:?}", message);
+        Ok(())
+    }
+
+    pub async fn flush(&self) -> Result<(), EventError> {
+        Ok(())
+    }
+}

--- a/crates/scouter_events/src/producer/mock/types.rs
+++ b/crates/scouter_events/src/producer/mock/types.rs
@@ -22,3 +22,9 @@ impl MockConfig {
         "MockConfig".to_string()
     }
 }
+
+impl Default for MockConfig {
+    fn default() -> Self {
+        MockConfig::new()
+    }
+}

--- a/crates/scouter_events/src/producer/mock/types.rs
+++ b/crates/scouter_events/src/producer/mock/types.rs
@@ -1,0 +1,24 @@
+use pyo3::prelude::*;
+use scouter_types::TransportType;
+
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct MockConfig {
+    #[pyo3(get)]
+    pub transport_type: TransportType,
+}
+
+#[pymethods]
+impl MockConfig {
+    #[new]
+    #[pyo3(signature = ())]
+    pub fn new() -> Self {
+        MockConfig {
+            transport_type: TransportType::Mock,
+        }
+    }
+
+    pub fn __str__(&self) -> String {
+        "MockConfig".to_string()
+    }
+}

--- a/crates/scouter_events/src/producer/mod.rs
+++ b/crates/scouter_events/src/producer/mod.rs
@@ -1,5 +1,6 @@
 pub mod http;
 pub mod kafka;
+pub mod mock;
 pub mod producer_enum;
 pub mod rabbitmq;
 pub mod redis;

--- a/crates/scouter_events/src/queue/py_queue.rs
+++ b/crates/scouter_events/src/queue/py_queue.rs
@@ -161,6 +161,7 @@ pub struct ScouterQueue {
     queues: HashMap<String, Py<QueueBus>>,
     _shared_runtime: Arc<tokio::runtime::Runtime>,
     completion_rxs: HashMap<String, oneshot::Receiver<()>>,
+    transport_config: TransportConfig,
 }
 
 #[pymethods]
@@ -214,6 +215,15 @@ impl ScouterQueue {
             Some(queue) => Ok(queue.bind(py)),
             None => Err(PyEventError::MissingQueueError(key.to_string())),
         }
+    }
+
+    #[getter]
+    /// Get the transport config for the ScouterQueue
+    pub fn transport_config<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> Result<Bound<'py, PyAny>, PyEventError> {
+        self.transport_config.to_py(py)
     }
 
     /// Triggers a global shutdown for all queues
@@ -344,6 +354,7 @@ impl ScouterQueue {
             // need to keep the runtime alive for the life of ScouterQueue
             _shared_runtime: shared_runtime,
             completion_rxs,
+            transport_config: config,
         })
     }
 }

--- a/crates/scouter_events/src/queue/types.rs
+++ b/crates/scouter_events/src/queue/types.rs
@@ -1,4 +1,5 @@
 use crate::producer::kafka::KafkaConfig;
+use crate::producer::mock::MockConfig;
 use crate::producer::rabbitmq::RabbitMQConfig;
 use crate::producer::redis::RedisConfig;
 use pyo3::prelude::*;
@@ -13,6 +14,7 @@ pub enum TransportConfig {
     Kafka(KafkaConfig),
     Http(HTTPConfig),
     Redis(RedisConfig),
+    Mock(MockConfig),
 }
 
 impl TransportConfig {
@@ -50,6 +52,10 @@ impl TransportConfig {
                 let redis_config = config.extract::<RedisConfig>()?;
                 Ok(TransportConfig::Redis(redis_config))
             }
+            TransportType::Mock => {
+                let mock_config = config.extract::<MockConfig>()?;
+                Ok(TransportConfig::Mock(mock_config))
+            }
         }
     }
 
@@ -60,6 +66,7 @@ impl TransportConfig {
             TransportConfig::Kafka(config) => config.clone().into_bound_py_any(py),
             TransportConfig::Http(config) => config.clone().into_bound_py_any(py),
             TransportConfig::Redis(config) => config.clone().into_bound_py_any(py),
+            TransportConfig::Mock(config) => config.clone().into_bound_py_any(py),
         }
     }
 }

--- a/crates/scouter_types/src/alert/dispatch.rs
+++ b/crates/scouter_types/src/alert/dispatch.rs
@@ -123,4 +123,5 @@ pub enum TransportType {
     RabbitMQ,
     Http,
     Redis,
+    Mock,
 }

--- a/py-scouter/python/scouter/queue/__init__.pyi
+++ b/py-scouter/python/scouter/queue/__init__.pyi
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from ..client import HTTPConfig
 from ..logging import LogLevel
 from ..observe import ObservabilityMetrics
+from ..test import MockConfig
 
 class TransportType:
     Kafka = "TransportType"
@@ -554,3 +555,9 @@ class ScouterQueue:
 
     def shutdown(self) -> None:
         """Shutdown the queue. This will close and flush all queues and transports"""
+
+    @property
+    def transport_config(
+        self,
+    ) -> Union[KafkaConfig, RabbitMQConfig, RedisConfig, HTTPConfig, MockConfig]:
+        """Return the transport configuration used by the queue"""

--- a/py-scouter/python/scouter/test/__init__.py
+++ b/py-scouter/python/scouter/test/__init__.py
@@ -2,5 +2,6 @@
 from .. import test
 
 ScouterTestServer = test.ScouterTestServer
+MockConfig = test.MockConfig
 
 __all__ = ["ScouterTestServer"]

--- a/py-scouter/python/scouter/test/__init__.py
+++ b/py-scouter/python/scouter/test/__init__.py
@@ -4,4 +4,4 @@ from .. import test
 ScouterTestServer = test.ScouterTestServer
 MockConfig = test.MockConfig
 
-__all__ = ["ScouterTestServer"]
+__all__ = ["ScouterTestServer", "MockConfig"]

--- a/py-scouter/python/scouter/test/__init__.pyi
+++ b/py-scouter/python/scouter/test/__init__.pyi
@@ -49,3 +49,7 @@ class ScouterTestServer:
     @staticmethod
     def cleanup() -> None:
         """Cleans up the test server."""
+
+class MockConfig:
+    def __init__(self) -> None:
+        """Mock configuration for the ScouterQueue"""

--- a/py-scouter/src/test.rs
+++ b/py-scouter/src/test.rs
@@ -1,5 +1,6 @@
 // add test logic
 use pyo3::prelude::*;
+use scouter_client::MockConfig;
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::debug;
@@ -215,5 +216,6 @@ impl ScouterTestServer {
 #[pymodule]
 pub fn test(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ScouterTestServer>()?;
+    m.add_class::<MockConfig>()?;
     Ok(())
 }

--- a/py-scouter/tests/integration/queue/conftest.py
+++ b/py-scouter/tests/integration/queue/conftest.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Iterator
+from unittest import mock
+
+import pytest
+from scouter.test import MockConfig
+
+
+@dataclass
+class MockEnvironment:
+    mock_config: MockConfig
+
+
+@pytest.fixture
+def mock_environment() -> Iterator[MockEnvironment]:
+    """
+    Fixture that patches HTTPConfig with MockConfig for testing.
+
+    Yields:
+        MockEnvironment: Contains the mock configuration.
+    """
+    with mock.patch("tests.integration.queue.test_mock.HTTPConfig", MockConfig):
+        yield MockEnvironment(mock_config=MockConfig())

--- a/py-scouter/tests/integration/queue/test_mock.py
+++ b/py-scouter/tests/integration/queue/test_mock.py
@@ -1,0 +1,45 @@
+import random
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from scouter.client import HTTPConfig, ScouterClient
+from scouter.drift import Drifter, PsiDriftConfig
+from scouter.queue import Feature, Features, ScouterQueue
+from scouter.test import MockConfig
+
+semver = f"{random.randint(0, 10)}.{random.randint(0, 10)}.{random.randint(0, 100)}"
+
+
+def test_mock_config(
+    mock_environment,  # this will mock the HTTPConfig import
+    http_scouter_server,
+    pandas_dataframe: pd.DataFrame,
+    psi_drift_config: PsiDriftConfig,
+):
+    scouter = Drifter()
+    client = ScouterClient()
+    profile = scouter.create_drift_profile(pandas_dataframe, psi_drift_config)
+    client.register_profile(profile)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = Path(temp_dir) / "profile.json"
+        profile.save_to_json(path)
+
+        ### Workflow
+        # 1. Create a ScouterQueue from path
+        queue = ScouterQueue.from_path({"a": path}, HTTPConfig())
+
+    # 2. Simulate records
+    records = pandas_dataframe.to_dict(orient="records")
+    for record in records:
+        features = Features(
+            features=[Feature.float(column_name, record[column_name]) for column_name in pandas_dataframe.columns]
+        )
+        # 3. Send records to Scouter
+        queue["a"].insert(features)
+
+    # 4. Shutdown the queue
+    queue.shutdown()
+
+    assert isinstance(queue.transport_config, MockConfig)


### PR DESCRIPTION

## Mock Producer for Scouter Queue Testing (#103)

This PR introduces a mock producer implementation to enable testing of `Scouter` code without requiring connections to external event services like Kafka.

### Changes

- **New `MockConfig`**: Added as a transport configuration type that can be used in place of real event service configurations
- **New `MockProducer`**: Handles event sending in test environments, allowing validation of `ScouterQueue` functionality

### Benefits

- Enables isolated unit testing of Scouter components
- Removes dependency on external services during development and CI
- Provides a reliable way to validate queue behavior in test scenarios

### Usage

The `MockConfig` can be configured as a transport config type, which will automatically use the `MockProducer` for event handling during tests.

```python
from scouter.test import MockConfig
from scouter.queue import ScouterQueue

queue = ScouterQueue.from_path(..., transport_config=MockConfig())
```

