### PR TITLE
113/postgres refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
         run: |
           python3 -m pip install scouter-ml --no-deps --no-index --force-reinstall --find-links dist
           pip install -r tests/requirements.txt
-          pytest --ignore tests/integration
+          pytest --ignore tests/integration --benchmark-skip
 
   python-release:
     if: github.event_name == 'release'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,6 +5128,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "cron",
+ "itertools 0.13.0",
  "rand 0.9.1",
  "scouter-dataframe",
  "scouter-settings",

--- a/crates/scouter_sql/Cargo.toml
+++ b/crates/scouter_sql/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = {workspace = true}
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde", "clock"] }
 cron = { workspace = true }
+itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/scouter_sql/src/sql/error.rs
+++ b/crates/scouter_sql/src/sql/error.rs
@@ -31,4 +31,10 @@ pub enum SqlError {
 
     #[error("Failed to get next run for cron schedule")]
     GetNextRunError,
+
+    #[error("Empty batch of records")]
+    EmptyBatchError,
+
+    #[error("Record batch type is not supported")]
+    UnsupportedBatchTypeError,
 }

--- a/crates/scouter_sql/src/sql/query.rs
+++ b/crates/scouter_sql/src/sql/query.rs
@@ -2,6 +2,8 @@
 
 // spc
 const INSERT_DRIFT_RECORD: &str = include_str!("scripts/spc/insert_spc_drift_record.sql");
+const INSERT_SPC_DRIFT_RECORD_BATCH: &str =
+    include_str!("scripts/spc/insert_spc_drift_record_batch.sql");
 const GET_SPC_FEATURES: &str = include_str!("scripts/spc/unique_spc_features.sql");
 const GET_BINNED_SPC_FEATURE_VALUES: &str =
     include_str!("scripts/spc/binned_spc_feature_values.sql");
@@ -12,6 +14,7 @@ const UPDATE_SPC_ENTITIES: &str = include_str!("scripts/spc/update_data_to_archi
 
 // psi
 const INSERT_BIN_COUNTS: &str = include_str!("scripts/psi/insert_bin_counts.sql");
+const INSERT_BIN_COUNTS_BATCH: &str = include_str!("scripts/psi/insert_bin_counts_batch.sql");
 const GET_BINNED_PSI_FEATURE_BINS: &str =
     include_str!("scripts/psi/binned_psi_feature_bin_proportions.sql");
 const GET_FEATURE_BIN_PROPORTIONS: &str =
@@ -28,6 +31,8 @@ const GET_BINNED_CUSTOM_METRIC_VALUES: &str =
 const GET_CUSTOM_METRIC_VALUES: &str = include_str!("scripts/custom/get_custom_metric_values.sql");
 const INSERT_CUSTOM_METRIC_VALUES: &str =
     include_str!("scripts/custom/insert_custom_metric_values.sql");
+const INSERT_CUSTOM_METRIC_VALUES_BATCH: &str =
+    include_str!("scripts/custom/insert_custom_metric_values_batch.sql");
 const GET_CUSTOM_ENTITIES: &str =
     include_str!("scripts/custom/get_custom_metric_entities_for_archive.sql");
 const GET_CUSTOM_DATA_FOR_ARCHIVE: &str =
@@ -90,6 +95,10 @@ pub enum Queries {
     GetFeatureBinProportions,
     GetCustomMetricValues,
     InsertCustomMetricValues,
+
+    InsertCustomMetricValuesBatch,
+    InsertSpcDriftRecordBatch,
+    InsertBinCountsBatch,
 
     // archive
     // entities
@@ -163,6 +172,11 @@ impl Queries {
             Queries::LastAdmin => SqlQuery::new(LAST_ADMIN),
             Queries::DeleteUser => SqlQuery::new(DELETE_USER),
             Queries::UpdateAlertStatus => SqlQuery::new(UPDATE_ALERT_STATUS),
+            Queries::InsertCustomMetricValuesBatch => {
+                SqlQuery::new(INSERT_CUSTOM_METRIC_VALUES_BATCH)
+            }
+            Queries::InsertSpcDriftRecordBatch => SqlQuery::new(INSERT_SPC_DRIFT_RECORD_BATCH),
+            Queries::InsertBinCountsBatch => SqlQuery::new(INSERT_BIN_COUNTS_BATCH),
         }
     }
 }

--- a/crates/scouter_sql/src/sql/scripts/custom/insert_custom_metric_values_batch.sql
+++ b/crates/scouter_sql/src/sql/scripts/custom/insert_custom_metric_values_batch.sql
@@ -1,0 +1,12 @@
+INSERT INTO scouter.custom_drift (created_at, name, space, version, metric, value)
+SELECT 
+    created_at, name, space, version, metric, value
+FROM UNNEST(
+    $1::timestamptz[], 
+    $2::text[], 
+    $3::text[], 
+    $4::text[], 
+    $5::text[], 
+    $6::double precision[]
+) AS t(created_at, name, space, version, metric, value)
+ON CONFLICT DO NOTHING;

--- a/crates/scouter_sql/src/sql/scripts/psi/insert_bin_counts_batch.sql
+++ b/crates/scouter_sql/src/sql/scripts/psi/insert_bin_counts_batch.sql
@@ -1,0 +1,13 @@
+INSERT INTO scouter.psi_drift (created_at, name, space, version, feature, bin_id, bin_count)
+SELECT 
+    created_at, name, space, version, feature, bin_id, bin_count
+FROM UNNEST(
+    $1::timestamptz[], 
+    $2::text[], 
+    $3::text[], 
+    $4::text[], 
+    $5::text[], 
+    $6::integer[], 
+    $7::integer[]
+) AS t(created_at, name, space, version, feature, bin_id, bin_count)
+ON CONFLICT DO NOTHING;

--- a/crates/scouter_sql/src/sql/scripts/spc/insert_spc_drift_record_batch.sql
+++ b/crates/scouter_sql/src/sql/scripts/spc/insert_spc_drift_record_batch.sql
@@ -1,0 +1,12 @@
+INSERT INTO scouter.spc_drift (created_at, name, space, version, feature, value)
+SELECT 
+    created_at, name, space, version, feature, value
+FROM UNNEST(
+    $1::timestamptz[], 
+    $2::text[], 
+    $3::text[], 
+    $4::text[], 
+    $5::text[], 
+    $6::double precision[]
+) AS t(created_at, name, space, version, feature, value)
+ON CONFLICT DO NOTHING;

--- a/crates/scouter_sql/src/sql/traits/custom.rs
+++ b/crates/scouter_sql/src/sql/traits/custom.rs
@@ -14,25 +14,6 @@ use tracing::{debug, instrument};
 
 #[async_trait]
 pub trait CustomMetricSqlLogic {
-    /// Inserts a custom metric value into the database.
-    async fn insert_custom_metric_value(
-        pool: &Pool<Postgres>,
-        record: &CustomMetricServerRecord,
-    ) -> Result<PgQueryResult, SqlError> {
-        let query = Queries::InsertCustomMetricValues.get_query();
-
-        sqlx::query(&query.sql)
-            .bind(record.created_at)
-            .bind(&record.name)
-            .bind(&record.space)
-            .bind(&record.version)
-            .bind(&record.metric)
-            .bind(record.value)
-            .execute(pool)
-            .await
-            .map_err(SqlError::SqlxError)
-    }
-
     async fn insert_custom_metric_values_batch(
         pool: &Pool<Postgres>,
         records: &[CustomMetricServerRecord],

--- a/crates/scouter_sql/src/sql/traits/psi.rs
+++ b/crates/scouter_sql/src/sql/traits/psi.rs
@@ -18,34 +18,14 @@ use tracing::{debug, instrument};
 
 #[async_trait]
 pub trait PsiSqlLogic {
-    /// Inserts a PSI bin count into the database.
+    /// Inserts multiple PSI bin counts into the database in a batch.
     ///
     /// # Arguments
     /// * `pool` - The database connection pool
-    /// * `record` - The PSI server record to insert
+    /// * `records` - The PSI server records to insert
     ///
     /// # Returns
     /// * A result containing the query result or an error
-    async fn insert_bin_counts(
-        pool: &Pool<Postgres>,
-        record: &PsiServerRecord,
-    ) -> Result<PgQueryResult, SqlError> {
-        let query = Queries::InsertBinCounts.get_query();
-
-        sqlx::query(&query.sql)
-            .bind(record.created_at)
-            .bind(&record.name)
-            .bind(&record.space)
-            .bind(&record.version)
-            .bind(&record.feature)
-            .bind(record.bin_id as i64)
-            .bind(record.bin_count as i64)
-            .execute(pool)
-            .await
-            .map_err(SqlError::SqlxError)
-    }
-
-    /// Inserts multiple PSI bin counts into the database in a batch.
     async fn insert_bin_counts_batch(
         pool: &Pool<Postgres>,
         records: &[PsiServerRecord],

--- a/crates/scouter_sql/src/sql/traits/spc.rs
+++ b/crates/scouter_sql/src/sql/traits/spc.rs
@@ -17,30 +17,12 @@ use tracing::{debug, instrument};
 
 #[async_trait]
 pub trait SpcSqlLogic {
-    /// Inserts a drift record into the database
-    ///
+    /// Inserts a batch of SPC drift records into the database
     /// # Arguments
-    ///
-    /// * `record` - A drift record to insert into the database
-    /// * `table_name` - The name of the table to insert the record into
-    ///
-    async fn insert_spc_drift_record(
-        pool: &Pool<Postgres>,
-        record: &SpcServerRecord,
-    ) -> Result<PgQueryResult, SqlError> {
-        let query = Queries::InsertDriftRecord.get_query();
-
-        Ok(sqlx::query(&query.sql)
-            .bind(record.created_at)
-            .bind(&record.name)
-            .bind(&record.space)
-            .bind(&record.version)
-            .bind(&record.feature)
-            .bind(record.value)
-            .execute(pool)
-            .await?)
-    }
-
+    /// * `pool` - The database connection pool
+    /// * `records` - The SPC drift records to insert
+    /// # Returns
+    /// * A result containing the query result or an error
     async fn insert_spc_drift_records_batch(
         pool: &Pool<Postgres>,
         records: &[SpcServerRecord],


### PR DESCRIPTION
## Pull Request

### Summary
As defined in #113 - This finds a middleground where instead of doing single inserts into the server from consumers, we perform batch inserts. The downside to this approach is the need to  iterate over the records to build insert arrays for the postgres insert and unnest logic. However, we're leverage `itertools::multiunzip` to minimize iterations and extract all vecs