### PR TITLE
update docs

### DIFF
--- a/py-scouter/docs/docs/server/index.md
+++ b/py-scouter/docs/docs/server/index.md
@@ -1,53 +1,144 @@
-The Scouter server is a rust-based server that is designed to be run independent of the python client. The server is responsible for handling the event system (via Kafka, RabbitMQ or the default queue system), database CRUD operations, and alerting.
+The Scouter server is a Rust-based server designed to run independent of the Python client. It handles the event system (via Kafka, RabbitMQ, Redis, or the default HTTP queue), database CRUD operations, background drift detection, GenAI evaluation, and alerting.
 
 Features:
 
-- <span class="text-secondary">**Event System**</span> - Scouter supports various third-party event systems such as Kafka and RabbitMQ. The event system is used to send events to the Scouter server for processing
-- <span class="text-secondary">**Database Storage**</span> - The Scouter server leverages **Postgres** (sqlx) for short-term data storage and **DataFusion** for long-term data storage
+- <span class="text-secondary">**Event System**</span> - Supports Kafka, RabbitMQ, Redis, and a built-in HTTP queue for sending monitoring events to the server
+- <span class="text-secondary">**Database Storage**</span> - Leverages **Postgres** (sqlx) for short-term data storage and **DataFusion** (Parquet/object store) for long-term archival
 - <span class="text-secondary">**Alerting**</span> - Integrates with OpsGenie and Slack for alerting
-- <span class="text-secondary">**Data Retention and Partitioning**</span> - Built-in data retention and partitioning strategies to keep your database clean and performant
-- <span class="text-secondary">**Authentication**</span> - Built-in authentication system for users
+- <span class="text-secondary">**Data Retention and Partitioning**</span> - Built-in retention and partitioning strategies via `pg_partman` and `pg_cron`
+- <span class="text-secondary">**Authentication**</span> - Built-in JWT authentication system
+- <span class="text-secondary">**gRPC + HTTP**</span> - Dual-protocol server (Axum HTTP on port 8000, Tonic gRPC on port 50051)
 
-## Getting Started
+---
 
-There are a few different ways to get up an running with the Scouter server.
+## Getting Started Locally
+
+This section is for **developers** who want to run Scouter locally for development or testing.
 
 ### Prerequisites
 
-- Scouter relies on a **Postgres** database for storing and retrieving data. You will need to have a Postgres database up and running before you can use Scouter. Scouter currently supports Postgres 16.3 and above.
+- [Rust](https://www.rust-lang.org/tools/install) (stable toolchain)
+- [Docker](https://docs.docker.com/get-docker/) + Docker Compose
+- [uv](https://docs.astral.sh/uv/) (for Python client work)
+- Git
 
-Once you have a Postgres database up and running, set the following environment variable before starting the Scouter server:
+### 1. Clone the repository
 
 ```bash
-export DATABASE_URI={your_postgres_uri}
+git clone https://github.com/demml/scouter.git
+cd scouter
 ```
 
-The default database URI is `postgresql://postgres:postgres@localhost:5432/postgres`. You can change this to point to your own Postgres database.
+### 2. Start the backend services
+
+This spins up PostgreSQL, Kafka, RabbitMQ, and Redis via Docker Compose:
+
+```bash
+make build.all_backends
+```
+
+This uses the `server-backends` Docker Compose profile which starts all services and waits until they are healthy before returning.
+
+### 3. Start the server
+
+```bash
+make start.server
+```
+
+This will:
+
+1. Kill any existing process on port 8000
+2. Start all backend services (if not already running)
+3. Build the server binary with all event bus features enabled
+4. Start the server in the background with Kafka, RabbitMQ, and Redis configured
+
+The server will be available at `http://localhost:8000`.
+
+### 4. Verify the server is running
+
+```bash
+curl http://localhost:8000/healthcheck
+```
+
+### 5. (Optional) Set up the Python client
+
+After making any Rust changes, rebuild the Python extension:
+
+```bash
+cd py-scouter
+make setup.project
+```
+
+Then configure the client to point at your local server:
+
+```bash
+export SCOUTER_SERVER_URI=http://localhost:8000
+export SCOUTER_USERNAME=admin
+export SCOUTER_PASSWORD=admin
+```
+
+### 6. Shut down all services
+
+```bash
+make build.shutdown
+```
+
+### Running tests locally
+
+```bash
+# Unit tests — no Docker required
+make test.unit
+
+# Integration tests — requires backends running
+make build.all_backends
+make test.needs_sql
+
+# Python unit tests
+cd py-scouter && make test.unit
+
+# Python integration tests — requires running server
+cd py-scouter && make test.integration
+```
+
+---
+
+## Getting Started (Production)
+
+There are a few different ways to deploy the Scouter server in production.
+
+### Prerequisites
+
+Scouter requires a **PostgreSQL 16.3+** database with the `pg_partman` and `pg_cron` extensions. See the [PostgreSQL setup guide](postgres.md) for details.
+
+Set the following environment variable before starting the server:
+
+```bash
+export DATABASE_URI=postgresql://<user>:<password>@<host>:<port>/<db>
+```
 
 ### Docker
 
-It is recommended to use one of our pre-built Docker images to get up and running quickly. New docker images are built and tagged on every version release and currently build for the following platforms:
+Pre-built Docker images are published on every release for the following platforms:
 
 <span class="text-primary">**Amd64** (x86_64-unknown-linux-gnu)</span>
 
 | Image | Tag Suffix | Features |
 |-------|------------|---------|
-| ubuntu | ubuntu | (kafka, RabbitMQ) |
-| alpine | alpine | (kafka, RabbitMQ) |
-| scratch | scratch | (kafka, RabbitMQ) |
-| debian | debian | (kafka, RabbitMQ) |
-| distroless | distroless | (kafka, RabbitMQ) |
+| ubuntu | ubuntu | Kafka, RabbitMQ |
+| alpine | alpine | Kafka, RabbitMQ |
+| scratch | scratch | Kafka, RabbitMQ |
+| debian | debian | Kafka, RabbitMQ |
+| distroless | distroless | Kafka, RabbitMQ |
 
 <span class="text-primary">**Arm64** (aarch64-unknown-linux-gnu)</span>
 
 | Image | Tag Suffix | Features |
 |-------|------------|---------|
-| ubuntu | ubuntu | (kafka, RabbitMQ) |
-| alpine | alpine | (kafka, RabbitMQ) |
-| scratch | scratch | (kafka, RabbitMQ) |
-| debian | debian | (kafka, RabbitMQ) |
-| distroless | distroless | (kafka, RabbitMQ) |
-
+| ubuntu | ubuntu | Kafka, RabbitMQ |
+| alpine | alpine | Kafka, RabbitMQ |
+| scratch | scratch | Kafka, RabbitMQ |
+| debian | debian | Kafka, RabbitMQ |
+| distroless | distroless | Kafka, RabbitMQ |
 
 #### Pull your image
 
@@ -58,113 +149,201 @@ docker pull demml/scouter:ubuntu-amd64-kafka-latest
 #### Run your image
 
 ```bash
-docker run -d --name scouter -p 8080:8080 demml/scouter:ubuntu-amd64-kafka-latest
+docker run -d \
+  --name scouter \
+  -p 8000:8000 \
+  -e DATABASE_URI=postgresql://user:pass@host:5432/db \
+  -e SCOUTER_ENCRYPT_SECRET=<your-32-byte-secret> \
+  -e SCOUTER_REFRESH_SECRET=<your-32-byte-secret> \
+  -e SCOUTER_BOOTSTRAP_KEY=<your-32-byte-key> \
+  demml/scouter:ubuntu-amd64-kafka-latest
 ```
 
+### Pre-built binaries
 
-### Execute prebuilt binary
+Binaries for various architectures are published on every release. Download and run the binary directly:
 
-Binaries for various architectures are published on every release. You can find them on the github release page, download and execute the binary.
+```bash
+# Download from GitHub releases
+curl -L https://github.com/demml/scouter/releases/latest/download/scouter-server-linux-amd64 -o scouter-server
+chmod +x scouter-server
+./scouter-server
+```
 
-Binaries can be found [here](https://github.com/demml/scouter/releases)
-
+Binaries can be found [here](https://github.com/demml/scouter/releases).
 
 ### Build from source
 
-To build the Scouter server from source, you will need to have the following dependencies installed:
-
-- Rust (with Cargo) [link](https://www.rust-lang.org/)
-
-Then you can build the server using the following command:
-
 ```bash
-cargo build scouter-server --release
+# Default build (HTTP queue only)
+cargo build -p scouter-server --release
+
+# With Kafka support
+cargo build -p scouter-server --release --features "kafka"
+
+# With RabbitMQ support
+cargo build -p scouter-server --release --features "rabbitmq"
+
+# With Redis support
+cargo build -p scouter-server --release --features "redis_events"
+
+# With all event bus features
+cargo build -p scouter-server --release --all-features
 ```
 
 ### Feature Flags
 
-Scouter server is built with a few feature flags that can be enabled or disabled at build time. The following feature flags are available:
+| Flag | Description |
+|------|-------------|
+| `kafka` | Enables Kafka consumer via the `rdkafka` crate |
+| `rabbitmq` | Enables RabbitMQ consumer via the `lapin` crate |
+| `redis_events` | Enables Redis Pub/Sub consumer |
 
-- `kafka` - Installs the necessary dependencies to use Kafka as the event system (`rdkafka` crate)
-
-```bash
-cargo build scouter-server --release --features "kafka"
-```
-
-- `rabbitmq` - Installs the necessary dependencies to use RabbitMQ as the event system (`lapin` crate)
-
-```bash
-cargo build scouter-server --release --features "rabbitmq"
-```
+---
 
 ## Environment Variables
 
-You can set a variety of environment variables to configure the Scouter server to your needs.
+### Database Variables
 
-### **Database Variables**
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DATABASE_URI` | PostgreSQL connection string | `postgresql://postgres:postgres@localhost:5432/postgres` |
+| `MAX_POOL_SIZE` | Maximum DB connections in the pool | `200` |
+| `MIN_POOL_SIZE` | Minimum DB connections in the pool | `20` |
+| `DB_ACQUIRE_TIMEOUT_SECONDS` | Timeout (seconds) to acquire a connection | `10` |
+| `DB_IDLE_TIMEOUT_SECONDS` | Idle connection timeout (seconds) | `300` |
+| `DB_MAX_LIFETIME_SECONDS` | Maximum connection lifetime (seconds) | `1800` |
+| `DB_TEST_BEFORE_ACQUIRE` | Test connections before acquiring from pool | `true` |
+| `DATA_RETENTION_PERIOD` | Days to retain data in the DB before archiving to long-term storage | `30` |
+| `TRACE_FLUSH_INTERVAL_SECONDS` | How often (seconds) to flush trace spans to the DB | `15` |
+| `TRACE_STALE_THRESHOLD_SECONDS` | How long (seconds) before an open trace span is considered stale | `30` |
+| `TRACE_CACHE_MAX_SIZE` | Maximum number of trace spans to hold in memory | `10000` |
+| `ENTITY_CACHE_MAX_SIZE` | Maximum number of entity definitions to cache in memory | `1000` |
 
-| Variable | Description | Feature | Default |
-|----------|-------------|---------|---------|
-| `DATABASE_URI` | Database connection URL | `All` | `postgresql://postgres:postgres@localhost:5432/postgres` |
-| `MAX_POOL_SIZE` | Maximum number of database connections in the pool | `All` | `30` |
-| `DATA_RETENTION_PERIOD` | Number of days to retain data in the database. After this time, data will be pushed to long-term storage via `DataFusion` | `All` | `30` |
+### Polling Variables
 
+Background workers that run scheduled drift detection and alerting.
 
-### **Polling Variables (For background drift detection)**
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `POLLING_WORKER_COUNT` | Number of drift detection/alerting worker threads | `4` |
+| `MAX_RETRIES` | Maximum retries for failed polling tasks | `3` |
 
-| Variable | Description | Feature | Default |
-|----------|-------------|---------|---------|
-| `POLLING_WORKER_COUNT` | Number of polling workers for processing scheduled tasks and alerting | `All` | `4` |
+### GenAI Polling Variables
 
-### **Kafka Variables (if enabled, for record consumption)**
+Background workers for asynchronous GenAI evaluation.
 
-| Variable | Description | Feature | Default |
-|----------|-------------|---------|---------|
-| `KAFKA_BROKERS` | Comma-separated list of Kafka broker addresses | `Kafka` | `localhost:9092` |
-| `KAFKA_TOPIC` | Kafka topic for sending data | `Kafka` | `scouter_monitoring` |
-| `KAFKA_GROUP` | Kafka consumer group ID | `Kafka` | `scouter` |
-| `KAFKA_OFFSET_RESET` | Kafka offset reset policy | `Kafka` | `earliest` |
-| `KAFKA_USERNAME` | Kafka username for authentication | `Kafka` | `None` |
-| `KAFKA_PASSWORD` | Kafka password for authentication | `Kafka` | `None` |
-| `KAFKA_SECURITY_PROTOCOL` | Kafka security protocol (e.g., `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, `SASL_SSL`) | `Kafka` | `SASL_SSL` |
-| `KAFKA_SASL_MECHANISM` | Kafka SASL mechanism | `Kafka` | `PLAIN` |
-| `KAFKA_CERT_LOCATION` | Path to the Kafka CA certificate file | `Kafka` | `None` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GENAI_WORKER_COUNT` | Number of GenAI evaluation worker threads | `2` |
+| `GENAI_MAX_RETRIES` | Maximum retries for failed GenAI evaluation tasks | `3` |
+| `GENAI_TRACE_WAIT_TIMEOUT_SECS` | Seconds to wait for a trace to arrive before timing out | `10` |
+| `GENAI_TRACE_BACKOFF_MILLIS` | Backoff delay (ms) between trace polling attempts | `100` |
+| `GENAI_TRACE_RESCHEDULE_DELAY_SECS` | Delay (seconds) before rescheduling a failed GenAI task | `30` |
 
+### HTTP Queue Variables
 
-### **RabbitMQ Variables (if enabled, for record consumption)**
+For the built-in HTTP event consumer (default transport, no extra setup required).
 
-| Variable | Description | Feature | Default |
-|----------|-------------|---------|---------|
-| `RABBITMQ_CONSUMER_COUNT` | Number of RabbitMQ consumers | `RabbitMQ` | `3` |
-| `RABBITMQ_PREFETCH_COUNT` | Number of messages to prefetch per consumer | `RabbitMQ` | `10` |
-| `RABBITMQ_ADDR` | RabbitMQ server address | `RabbitMQ` | `amqp://guest:guest@127.0.0.1:5672/%2f` |
-| `RABBITMQ_QUEUE` | RabbitMQ queue name | `RabbitMQ` | `scouter_monitoring` |
-| `RABBITMQ_CONSUMER_TAG` | RabbitMQ consumer tag | `RabbitMQ` | `scouter` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HTTP_CONSUMER_WORKER_COUNT` | Number of HTTP consumer worker threads | `1` |
 
+### Kafka Variables
 
-### **Authentication**
+Enabled when `KAFKA_BROKERS` is set and the `kafka` feature flag is compiled in.
 
-Scouter has built-in authentication support for JWT tokens. You can set the following environment variables to enable authentication:
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KAFKA_BROKERS` | Comma-separated list of Kafka broker addresses | `localhost:9092` |
+| `KAFKA_WORKER_COUNT` | Number of Kafka consumer worker threads | `3` |
+| `KAFKA_TOPIC` | Kafka topic(s) to consume (comma-separated) | `scouter_monitoring` |
+| `KAFKA_GROUP` | Kafka consumer group ID | `scouter` |
+| `KAFKA_OFFSET_RESET` | Offset reset policy | `earliest` |
+| `KAFKA_USERNAME` | SASL username | — |
+| `KAFKA_PASSWORD` | SASL password | — |
+| `KAFKA_SECURITY_PROTOCOL` | Security protocol (`PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, `SASL_SSL`) | `SASL_SSL` |
+| `KAFKA_SASL_MECHANISM` | SASL mechanism | `PLAIN` |
+| `KAFKA_CERT_LOCATION` | Path to CA certificate file | — |
 
-- `SCOUTER_ENCRYPT_SECRET`: Secret key used to sign JWT tokens. If not set, scouter will use a default **deterministic** key. This is not recommended for production use cases. Scouter requires a pbdkdf2::HmacSha256 key with a length of 32 bytes.
-- `SCOUTER_REFRESH_SECRET`: Secret key used to sign refresh tokens. If not set, scouter will use a default **deterministic** key. This is not recommended for production use cases. Scouter requires a pbdkdf2::HmacSha256 key with a length of 32 bytes.
-- `SCOUTER_BOOTSTRAP_KEY`: Secret key used to bootstrap the server. This is used to create the initial admin user and should be set to a strong random value. If not set, scouter will use a default. This is also a pbdkdf2::HmacSha256 key with a length of 32 bytes. This can be used as a shared key for integration work as well. For example, when setting up an [opsml](https://docs.demml.io/opsml/docs/setup/overview/) server, you can user this key to sync user accounts between the two servers.
+### RabbitMQ Variables
 
-### **ObjectStore Variables (For long-term storage)**
+Enabled when `RABBITMQ_ADDR` is set and the `rabbitmq` feature flag is compiled in.
 
-| Variable | Description | Feature | Default |
-|----------|-------------|---------|---------|
-| `SCOUTER_STORAGE_URI` | The URI of the object store to use for long-term storage. The default is `./scouter_storage`. Currently, gcs, s3, azure and local storage are supported. If using cloud storage, provide the appropriate prefix and bucket (e.g. gs://scouter, s3://scouter, az://scouter) | `ObjectStore` | `./scouter_storage` |
-| `AWS_REGION` | The AWS region to use for S3 storage. The default is `us-east-1` | `ObjectStore` | `us-east-1` |
-| `GOOGLE_ACCOUNT_JSON_BASE64` | The base64 encoded JSON key file to use for GCS storage. This is an optional environment variable that can be used in addition to how the `object-store` GoogleCloudStorageBuilder retrieves credentials | `ObjectStore` | `None` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RABBITMQ_ADDR` | RabbitMQ AMQP address | `amqp://guest:guest@127.0.0.1:5672/%2f` |
+| `RABBITMQ_CONSUMER_COUNT` | Number of RabbitMQ consumers | `3` |
+| `RABBITMQ_PREFETCH_COUNT` | Messages to prefetch per consumer | `10` |
+| `RABBITMQ_QUEUE` | Queue name | `scouter_monitoring` |
+| `RABBITMQ_CONSUMER_TAG` | Consumer tag | `scouter` |
 
+### Redis Variables
 
-## Object Store Providers
-Scouter leverage's the [object-store](https://docs.rs/object_store/latest/object_store/index.html) crate for writing to object stores. The following object stores are supported. Please refer to the object-store crate for more information on how to configure each object store.
+Enabled when `REDIS_ADDR` is set and the `redis_events` feature flag is compiled in.
 
-Providers:
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `REDIS_ADDR` | Redis server address | `redis://127.0.0.1:6379` |
+| `REDIS_CONSUMER_COUNT` | Number of Redis consumer workers | `3` |
+| `REDIS_CHANNEL` | Redis Pub/Sub channel name | `scouter_monitoring` |
 
-- `google_cloud_storage` - [link](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html)
-- `aws_s3` - [link](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html)
-- `azure` - [link](https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html)
+### Authentication
 
+Scouter uses JWT-based authentication. For production deployments, always set all three secrets to strong random values — if any are unset, Scouter will fall back to a **deterministic default key** which is unsafe.
+
+| Variable | Description |
+|----------|-------------|
+| `SCOUTER_ENCRYPT_SECRET` | Signs JWT access tokens. Must be a base64-encoded PBKDF2-HMAC-SHA256 key (32 bytes). |
+| `SCOUTER_REFRESH_SECRET` | Signs JWT refresh tokens. Same format as above. |
+| `SCOUTER_BOOTSTRAP_KEY` | Used to create the initial admin user on first startup. Also serves as a shared key for inter-service authentication (e.g. OpsML integration). Same format as above. |
+
+To generate a suitable secret:
+
+```bash
+openssl rand -base64 32
+```
+
+### Object Store Variables
+
+Controls where archived data (expired from PostgreSQL) is written for long-term storage.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SCOUTER_STORAGE_URI` | Object store URI. Supports `s3://`, `gs://`, `az://`, or a local path | `./scouter_storage` |
+| `AWS_REGION` | AWS region (required for S3) | `us-east-1` |
+| `GOOGLE_ACCOUNT_JSON_BASE64` | Base64-encoded GCP service account JSON (optional, for GCS) | — |
+
+**URI examples:**
+
+```bash
+# AWS S3
+export SCOUTER_STORAGE_URI=s3://my-scouter-bucket
+
+# Google Cloud Storage
+export SCOUTER_STORAGE_URI=gs://my-scouter-bucket
+
+# Azure Blob Storage
+export SCOUTER_STORAGE_URI=az://my-scouter-container
+
+# Local filesystem (default)
+export SCOUTER_STORAGE_URI=./scouter_storage
+```
+
+See the [object-store crate](https://docs.rs/object_store/latest/object_store/index.html) docs for provider-specific credential configuration:
+
+- [AWS S3](https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html)
+- [Google Cloud Storage](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html)
+- [Azure Blob Storage](https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html)
+
+### Client Variables
+
+These are used by the Python client (`ScouterClient`, `ScouterQueue`) to connect to the server.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SCOUTER_SERVER_URI` | HTTP server address | `http://localhost:8000` |
+| `SCOUTER_GRPC_URI` | gRPC server address | `http://localhost:50051` |
+| `SCOUTER_USERNAME` | Username for authentication | `guest` |
+| `SCOUTER_PASSWORD` | Password for authentication | `guest` |
+| `SCOUTER_AUTH_TOKEN` | Pre-issued auth token (alternative to username/password) | — |

--- a/py-scouter/docs/docs/specs/ts-component-data-archive.md
+++ b/py-scouter/docs/docs/specs/ts-component-data-archive.md
@@ -3,7 +3,7 @@
 ## Overview
 The data archive component and architecture is meant to provide a way to maintain database performance, while retaining data in a long-term storage solution.  Importantly, Scouter focuses on providing real-time monitoring capabilities and alerting. And while most of this relies on having short-term data (defined as 60 days), there are some use cases where a user may want to visualize or audit data from longer periods of time.  This component is meant to provide a way to do that.
 
-TLDR: Scouter deletes all records > 60 days old in order to maintain database performance, so we need a retention strategy for expired data in the event a user needs access to it.
+TLDR: Scouter deletes records older than the configured retention period (default: 30 days) in order to maintain database performance, so we need a retention strategy for expired data in the event a user needs access to it.
 
 
 ## How it works
@@ -27,7 +27,7 @@ Accepted environment variables are:
 
 - `AWS_REGION`: The AWS region for the object storage provider. This is only required if the `SCOUTER_STORAGE_URI` is set to `s3://<bucket-name>`. It defaults to `us-east-1` if not set.
 
-In addition to `ObjectStorageSettings`, `DatabaseSettings` now takes on an additional environment variable `DATA_RETENTION_PERIOD` which indicates how long data should be retained in the database before moving it to long-term storage. Note this is only for **copying** data to long-term storage. The actual deletion of data is still handled by `pgCron`. The default value is 60 days.
+In addition to `ObjectStorageSettings`, `DatabaseSettings` now takes on an additional environment variable `DATA_RETENTION_PERIOD` which indicates how long data should be retained in the database before moving it to long-term storage. Note this is only for **copying** data to long-term storage. The actual deletion of data is still handled by `pgCron`. The default value is **30 days**.
 
 ## Component Architecture
 

--- a/py-scouter/docs/docs/specs/ts-component-genai-eval.md
+++ b/py-scouter/docs/docs/specs/ts-component-genai-eval.md
@@ -1,0 +1,183 @@
+# Technical Component Specification: GenAI Evaluation
+
+## Overview
+
+The GenAI evaluation component provides two complementary workflows for assessing the quality, correctness, and safety of LLM-powered applications:
+
+- **Online evaluation** — Real-time sampling and asynchronous evaluation of production inference traffic
+- **Offline evaluation** — Batch evaluation of datasets for pre-deployment testing, regression analysis, and benchmarking
+
+Both modes share a common task model (`AssertionTask`, `LLMJudgeTask`) and a common context system for extracting and passing data between evaluation steps.
+
+---
+
+## Online Evaluation
+
+### How it works
+
+Online evaluation integrates directly into the production inference path. A `GenAIEvalProfile` is registered with the Scouter server, defining what to evaluate and how. At inference time, the application inserts `GenAIEvalRecord` objects into a `ScouterQueue`. The server samples records based on a configurable `sample_ratio`, then runs evaluation tasks asynchronously via the GenAI poller background worker.
+
+```
+Inference request
+      │
+      ▼
+Application inserts GenAIEvalRecord into ScouterQueue
+      │
+      ▼
+Scouter server samples based on sample_ratio
+      │
+      ▼
+GenAI poller worker picks up sampled records
+      │
+      ▼
+Evaluation tasks run (AssertionTask / LLMJudgeTask)
+      │
+      ▼
+Alert conditions checked → dispatch if threshold crossed
+```
+
+### GenAIEvalRecord
+
+A `GenAIEvalRecord` captures the context of a single inference call. It accepts a Python `dict` or Pydantic `BaseModel` as context, and an optional `Prompt`.
+
+```python
+from scouter import GenAIEvalRecord
+
+record = GenAIEvalRecord(
+    context={
+        "input": user_message,
+        "response": model_response,
+        "model": "gpt-4o",
+    }
+)
+
+queue["my-genai-profile"].insert(record)
+```
+
+### GenAIEvalProfile
+
+The profile defines the evaluation configuration, including tasks, alert thresholds, and sampling ratio.
+
+```python
+from scouter.evaluate import GenAIEvalProfile, GenAIEvalConfig
+from scouter.alert import ConsoleDispatchConfig
+from scouter.types import CommonCrons
+
+profile = GenAIEvalProfile(
+    config=GenAIEvalConfig(
+        space="my-space",
+        name="my-model",
+        version="1.0.0",
+        sample_ratio=0.1,           # Evaluate 10% of production traffic
+        alert_config=ConsoleDispatchConfig(
+            schedule=CommonCrons.EveryHour,
+        ),
+    ),
+    tasks=[assertion_task, judge_task],
+)
+```
+
+---
+
+## Offline Evaluation
+
+Offline evaluation runs batch evaluation against a `GenAIEvalDataset`. This is useful for pre-deployment testing, regression analysis, and comparing model versions.
+
+### Workflow
+
+```python
+from scouter.evaluate import GenAIEvalDataset, GenAIEvalConfig
+
+dataset = GenAIEvalDataset(
+    config=GenAIEvalConfig(
+        space="my-space",
+        name="my-model",
+        version="1.0.0",
+    ),
+    tasks=[assertion_task, judge_task],
+    records=[record_1, record_2, ...],
+)
+
+results = dataset.evaluate()
+```
+
+---
+
+## Evaluation Tasks
+
+### AssertionTask
+
+Deterministic, rule-based evaluation. Supports 50+ `ComparisonOperator` values covering string, numeric, collection, and JSON checks.
+
+```python
+from scouter.evaluate import AssertionTask, ComparisonOperator
+
+task = AssertionTask(
+    task_id="check_json_response",
+    context_path="response",                  # dot-notation field extraction
+    operator=ComparisonOperator.IsJson,
+    condition=True,                           # acts as a gate: skip downstream tasks on failure
+)
+```
+
+**Key features:**
+- `context_path`: Dot-notation path to extract a field from the record context (e.g. `"response.choices.0.message.content"`)
+- `condition=True`: When set, a failed assertion skips all downstream tasks that depend on this one
+- Template variable substitution: use `${field_name}` in expected values to reference context fields
+
+### LLMJudgeTask
+
+LLM-powered semantic evaluation. Sends context and a prompt to an LLM and extracts a structured score using Pydantic models.
+
+```python
+from scouter.evaluate import LLMJudgeTask
+from scouter.genai import Prompt
+
+task = LLMJudgeTask(
+    task_id="judge_helpfulness",
+    prompt=Prompt(
+        message="Rate the helpfulness of the following response on a scale of 1–5.\n\nUser: ${input}\nResponse: ${response}",
+    ),
+    context_path="score",                    # extract 'score' field from LLM response
+    depends_on=["check_json_response"],      # only run if assertion gate passed
+)
+```
+
+**Supported LLM providers:**
+- OpenAI (via `OPENAI_API_KEY`)
+- Anthropic (via `ANTHROPIC_API_KEY`)
+- Google Gemini (via `GOOGLE_API_KEY` / service account)
+
+---
+
+## Task Dependencies
+
+Tasks can declare `depends_on` to form a dependency graph. Each task receives the base record context plus the outputs of all declared dependencies.
+
+```python
+tasks = [
+    AssertionTask(task_id="validate_format", context_path="response", operator=ComparisonOperator.IsJson, condition=True),
+    LLMJudgeTask(task_id="judge_quality", depends_on=["validate_format"], ...),
+    AssertionTask(task_id="check_score", context_path="judge_quality.score", operator=ComparisonOperator.GreaterThan, expected=3, depends_on=["judge_quality"]),
+]
+```
+
+---
+
+## Background Worker: GenAI Poller
+
+The `GenAIPollerSettings` controls the server-side worker that processes queued evaluation records.
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| Worker count | `GENAI_WORKER_COUNT` | `2` | Number of concurrent evaluation workers |
+| Max retries | `GENAI_MAX_RETRIES` | `3` | Retries on task failure |
+| Trace wait timeout | `GENAI_TRACE_WAIT_TIMEOUT_SECS` | `10` | Seconds to wait for an associated trace before giving up |
+| Trace backoff | `GENAI_TRACE_BACKOFF_MILLIS` | `100` | Delay between trace polling attempts |
+| Reschedule delay | `GENAI_TRACE_RESCHEDULE_DELAY_SECS` | `30` | Delay before rescheduling a failed evaluation task |
+
+---
+
+*Version: 1.0*
+*Last Updated: 2026-03-01*
+*Component Owner: Steven Forrester*

--- a/py-scouter/mkdocs.yml
+++ b/py-scouter/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Archive: "docs/specs/ts-component-data-archive.md"
       - Queue: "docs/specs/ts-component-scouter-queue.md"
       - gRPC: "docs/specs/ts-component-scouter-grpc.md"
+      - GenAI Evaluation: "docs/specs/ts-component-genai-eval.md"
   - API Documentation:
       - API: "docs/api/stubs.md"
 


### PR DESCRIPTION
## Summary

- #213 

   - **Rewrote `docs/server/index.md`** to be a comprehensive server reference covering both local development and production deployment
   - **Fixed correctness issues** in the existing env var table
   - **Added new GenAI evaluation tech spec** (`ts-component-genai-eval.md`)
   - **Fixed retention period default** in the data archive tech spec

   ## Changes

   ### `docs/server/index.md`
   **Bug fixes:**
   - `MAX_POOL_SIZE` default corrected from `30` → `200` (actual code default)
   - `cargo build` command fixed to `cargo build -p scouter-server --release`
   - Docker `run` port fixed from `8080:8080` → `8000:8000`

   **New: Getting Started Locally section** — step-by-step guide for developers: clone → `make build.all_backends` → `make start.server` → verify → Python client setup → shutdown
   → test commands

   **New env vars documented** (previously missing entirely):
   - `DatabaseSettings`: `MIN_POOL_SIZE`, `DB_ACQUIRE_TIMEOUT_SECONDS`, `DB_IDLE_TIMEOUT_SECONDS`, `DB_MAX_LIFETIME_SECONDS`, `DB_TEST_BEFORE_ACQUIRE`,
   `TRACE_FLUSH_INTERVAL_SECONDS`, `TRACE_STALE_THRESHOLD_SECONDS`, `TRACE_CACHE_MAX_SIZE`, `ENTITY_CACHE_MAX_SIZE`
   - `PollingSettings`: `MAX_RETRIES`
   - **GenAI Polling** (entirely new section): `GENAI_WORKER_COUNT`, `GENAI_MAX_RETRIES`, `GENAI_TRACE_WAIT_TIMEOUT_SECS`, `GENAI_TRACE_BACKOFF_MILLIS`,
   `GENAI_TRACE_RESCHEDULE_DELAY_SECS`
   - **HTTP Queue** (new section): `HTTP_CONSUMER_WORKER_COUNT`
   - **Redis** (new section): `REDIS_ADDR`, `REDIS_CONSUMER_COUNT`, `REDIS_CHANNEL`
   - **Client Variables** (new section): `SCOUTER_SERVER_URI`, `SCOUTER_GRPC_URI`, `SCOUTER_USERNAME`, `SCOUTER_PASSWORD`, `SCOUTER_AUTH_TOKEN`
   - `redis_events` feature flag added to build-from-source docs

   ### `ts-component-data-archive.md`
   - Fixed retention period default: "60 days" → 30 days (matches `DATA_RETENTION_PERIOD` in code)

   ### `ts-component-genai-eval.md` (new)
   - Full tech spec covering online evaluation, offline evaluation, `AssertionTask`, `LLMJudgeTask`, task dependency graphs, and GenAI poller worker settings

   ### `mkdocs.yml`
   - Added GenAI Evaluation spec to the Tech Specs nav