### PR TITLE
Add search query to TraceFilters

### DIFF
--- a/crates/scouter_client/src/http/client.rs
+++ b/crates/scouter_client/src/http/client.rs
@@ -195,26 +195,16 @@ impl ScouterClient {
         cursor_trace_id: Option<String>,
         direction: Option<String>,
     ) -> Result<TracePaginationResponse, ClientError> {
-        let mut filters =
-            TraceFilters::parse(q).map_err(|err| ClientError::PyError(err.to_string()))?;
-        if let Some(start_time) = start_time {
-            filters.start_time = Some(start_time);
-        }
-        if let Some(end_time) = end_time {
-            filters.end_time = Some(end_time);
-        }
-        if let Some(limit) = limit {
-            filters.limit = Some(limit);
-        }
-        if let Some(cursor_start_time) = cursor_start_time {
-            filters.cursor_start_time = Some(cursor_start_time);
-        }
-        if let Some(cursor_trace_id) = cursor_trace_id {
-            filters.cursor_trace_id = Some(cursor_trace_id);
-        }
-        if let Some(direction) = direction {
-            filters.direction = Some(direction);
-        }
+        let filters = TraceFilters {
+            query: Some(q.to_string()),
+            start_time,
+            end_time,
+            limit,
+            cursor_start_time,
+            cursor_trace_id,
+            direction,
+            ..Default::default()
+        };
 
         let response = self.client.request(
             Routes::PaginatedTraces,

--- a/crates/scouter_server/src/api/routes/trace/route.rs
+++ b/crates/scouter_server/src/api/routes/trace/route.rs
@@ -34,11 +34,6 @@ use std::sync::Arc;
 use tracing::instrument;
 use tracing::{debug, error};
 
-#[derive(Debug, serde::Deserialize)]
-pub struct SearchQ {
-    pub q: Option<String>,
-}
-
 fn invalid_search_query(err: impl std::fmt::Display) -> (StatusCode, Json<ScouterServerError>) {
     (
         StatusCode::BAD_REQUEST,
@@ -110,14 +105,17 @@ fn validate_clause(clause: &FilterClause) -> Result<(), String> {
     validate_filter_clause(clause).map_err(|err| err.to_string())
 }
 
-fn merge_q_into_filters(
-    q: Option<String>,
-    body: TraceFilters,
+fn normalize_trace_filters(
+    mut body: TraceFilters,
 ) -> Result<TraceFilters, (StatusCode, Json<ScouterServerError>)> {
-    let Some(q) = q.as_deref().map(str::trim).filter(|s| !s.is_empty()) else {
+    let Some(query) = body.query.take() else {
         return Ok(body);
     };
-    let parsed = parse_search_query(q).map_err(invalid_search_query)?;
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok(body);
+    }
+    let parsed = parse_search_query(query).map_err(invalid_search_query)?;
     Ok(merge_filters(parsed, body))
 }
 
@@ -146,6 +144,7 @@ fn merge_filters(parsed: TraceFilters, body: TraceFilters) -> TraceFilters {
         direction: body.direction.or(parsed.direction),
         trace_ids: merge_vec(parsed.trace_ids, body.trace_ids),
         entity_uid: body.entity_uid.or(parsed.entity_uid),
+        query: None,
     }
 }
 
@@ -197,7 +196,6 @@ pub async fn get_trace_baggage(
     post,
     path = "/scouter/trace/paginated",
     request_body = TraceFilters,
-    params(("q" = Option<String>, Query, description = "Optional Lucene-style search query")),
     responses(
         (status = 200, description = "Paginated traces", body = TracePaginationResponse),
         (status = 500, description = "Internal server error", body = ScouterServerError),
@@ -208,10 +206,9 @@ pub async fn get_trace_baggage(
 #[instrument(skip_all)]
 pub async fn paginated_traces(
     State(data): State<Arc<AppState>>,
-    Query(search): Query<SearchQ>,
     Json(body): Json<TraceFilters>,
 ) -> Result<Json<TracePaginationResponse>, (StatusCode, Json<ScouterServerError>)> {
-    let body = merge_q_into_filters(search.q, body)?;
+    let body = normalize_trace_filters(body)?;
     validate_filters(&body)?;
     debug!(
         "paginated_traces: limit={:?} start={:?} end={:?}",
@@ -519,7 +516,6 @@ pub async fn trace_metrics(
     post,
     path = "/scouter/trace/facets",
     request_body = TraceFilters,
-    params(("q" = Option<String>, Query, description = "Optional Lucene-style search query")),
     responses(
         (status = 200, description = "Trace facets", body = TraceFacetsResponse),
         (status = 500, description = "Internal server error", body = ScouterServerError),
@@ -530,10 +526,9 @@ pub async fn trace_metrics(
 #[instrument(skip_all)]
 pub async fn get_trace_facets(
     State(data): State<Arc<AppState>>,
-    Query(search): Query<SearchQ>,
     Json(body): Json<TraceFilters>,
 ) -> Result<Json<TraceFacetsResponse>, (StatusCode, Json<ScouterServerError>)> {
-    let body = merge_q_into_filters(search.q, body)?;
+    let body = normalize_trace_filters(body)?;
     validate_filters(&body)?;
     debug!(
         "trace_facets: limit={:?} start={:?} end={:?}",
@@ -562,7 +557,6 @@ pub async fn get_trace_facets(
     post,
     path = "/scouter/trace/spans/filters",
     request_body = TraceFilters,
-    params(("q" = Option<String>, Query, description = "Optional Lucene-style search query")),
     responses(
         (status = 200, description = "Trace spans matching filters", body = TraceSpansResponse),
         (status = 500, description = "Internal server error", body = ScouterServerError),
@@ -574,10 +568,9 @@ pub async fn get_trace_facets(
 pub async fn query_spans_from_filters(
     State(data): State<Arc<AppState>>,
     Extension(perms): Extension<UserPermissions>,
-    Query(search): Query<SearchQ>,
     Json(body): Json<TraceFilters>,
 ) -> Result<Json<TraceSpansResponse>, (StatusCode, Json<ScouterServerError>)> {
-    let body = merge_q_into_filters(search.q, body)?;
+    let body = normalize_trace_filters(body)?;
     validate_filters(&body)?;
     let spans = data
         .trace_service
@@ -815,14 +808,34 @@ mod tests {
     }
 
     #[test]
-    fn empty_q_returns_body_unchanged() {
+    fn empty_query_returns_body_unchanged() {
         let body = TraceFilters {
             limit: Some(25),
             ..Default::default()
         };
-        let result = merge_q_into_filters(None, body.clone()).unwrap();
+        let result = normalize_trace_filters(body.clone()).unwrap();
         assert_eq!(result.limit, Some(25));
         assert!(result.clause.is_none());
+    }
+
+    #[test]
+    fn trace_filter_body_query_merges_supported_fields_and_keeps_body_precedence() {
+        let body_ts = Utc::now();
+        let body = TraceFilters {
+            start_time: Some(body_ts),
+            entity_uid: Some("body-entity".to_string()),
+            query: Some(
+                "start_time:2026-01-01T00:00:00Z entity_uid:query-entity component:kafka"
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let result = normalize_trace_filters(body).unwrap();
+        assert_eq!(result.start_time, Some(body_ts));
+        assert_eq!(result.entity_uid.as_deref(), Some("body-entity"));
+        assert!(matches!(result.clause, Some(FilterClause::Attr { .. })));
+        assert!(result.query.is_none());
     }
 
     #[test]

--- a/crates/scouter_server/tests/api/trace.rs
+++ b/crates/scouter_server/tests/api/trace.rs
@@ -16,12 +16,6 @@ use scouter_types::{
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
-fn with_q(path: &str, q: &str) -> String {
-    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
-    serializer.append_pair("q", q);
-    format!("{path}?{}", serializer.finish())
-}
-
 async fn fetch_paginated(helper: &TestHelper, filters: &TraceFilters) -> TracePaginationResponse {
     let body = serde_json::to_string(filters).unwrap();
     let request = Request::builder()
@@ -38,12 +32,14 @@ async fn fetch_paginated(helper: &TestHelper, filters: &TraceFilters) -> TracePa
 
 async fn fetch_paginated_with_query(
     helper: &TestHelper,
-    q: &str,
+    query: &str,
     filters: &TraceFilters,
 ) -> (StatusCode, Vec<u8>) {
+    let mut filters = filters.clone();
+    filters.query = Some(query.to_string());
     let body = serde_json::to_string(&filters).unwrap();
     let request = Request::builder()
-        .uri(with_q("/scouter/trace/paginated", q))
+        .uri("/scouter/trace/paginated")
         .method("POST")
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body))
@@ -612,7 +608,7 @@ async fn test_trace_search_query_user_flow() {
     assert_eq!(
         post_page.items.len(),
         body_page.items.len(),
-        "POST URL query should merge into an empty body as the parsed clause"
+        "POST body query should merge into an empty body as the parsed clause"
     );
 
     let (status, _body) = fetch_paginated_with_query(
@@ -629,7 +625,7 @@ async fn test_trace_search_query_user_flow() {
 }
 
 #[tokio::test]
-async fn test_trace_search_q_and_body_are_and_merged() {
+async fn test_trace_search_query_and_body_are_and_merged() {
     let helper = setup_test().await;
     helper.generate_trace_data().await.unwrap();
     wait_for_paginated_count(&helper, 100).await;
@@ -735,8 +731,11 @@ async fn test_trace_query_is_merged_for_metrics_facets_and_spans() {
     let body_facets = fetch_facets(&helper, &body_filters).await;
     let (status, facets_q_body) = fetch_facets_raw(
         &helper,
-        &with_q("/scouter/trace/facets", "component:kafka"),
-        &TraceFilters::default(),
+        "/scouter/trace/facets",
+        &TraceFilters {
+            query: Some("component:kafka".to_string()),
+            ..Default::default()
+        },
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -749,8 +748,11 @@ async fn test_trace_query_is_merged_for_metrics_facets_and_spans() {
     };
     let (status, merged_facets_body) = fetch_facets_raw(
         &helper,
-        &with_q("/scouter/trace/facets", "component:kafka"),
-        &merged_filters,
+        "/scouter/trace/facets",
+        &TraceFilters {
+            query: Some("component:kafka".to_string()),
+            ..merged_filters.clone()
+        },
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -763,8 +765,11 @@ async fn test_trace_query_is_merged_for_metrics_facets_and_spans() {
     let body_spans = fetch_spans_from_filters(&helper, &body_filters).await;
     let (status, spans_q_body) = fetch_spans_from_filters_raw(
         &helper,
-        &with_q("/scouter/trace/spans/filters", "component:kafka"),
-        &TraceFilters::default(),
+        "/scouter/trace/spans/filters",
+        &TraceFilters {
+            query: Some("component:kafka".to_string()),
+            ..Default::default()
+        },
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -773,8 +778,11 @@ async fn test_trace_query_is_merged_for_metrics_facets_and_spans() {
 
     let (status, merged_spans_body) = fetch_spans_from_filters_raw(
         &helper,
-        &with_q("/scouter/trace/spans/filters", "component:kafka"),
-        &merged_filters,
+        "/scouter/trace/spans/filters",
+        &TraceFilters {
+            query: Some("component:kafka".to_string()),
+            ..merged_filters
+        },
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -801,15 +809,21 @@ async fn test_trace_query_is_merged_for_metrics_facets_and_spans() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let (status, _) = fetch_facets_raw(
         &helper,
-        &with_q("/scouter/trace/facets", invalid_q),
-        &TraceFilters::default(),
+        "/scouter/trace/facets",
+        &TraceFilters {
+            query: Some(invalid_q.to_string()),
+            ..Default::default()
+        },
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let (status, _) = fetch_spans_from_filters_raw(
         &helper,
-        &with_q("/scouter/trace/spans/filters", invalid_q),
-        &TraceFilters::default(),
+        "/scouter/trace/spans/filters",
+        &TraceFilters {
+            query: Some(invalid_q.to_string()),
+            ..Default::default()
+        },
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);

--- a/crates/scouter_types/src/trace/sql.rs
+++ b/crates/scouter_types/src/trace/sql.rs
@@ -215,6 +215,9 @@ pub struct TraceFilters {
     pub trace_ids: Option<Vec<String>>,
     #[pyo3(get, set)]
     pub entity_uid: Option<String>,
+    #[serde(default)]
+    #[pyo3(get, set)]
+    pub query: Option<String>,
 }
 
 #[pymethods]
@@ -229,7 +232,8 @@ impl TraceFilters {
         cursor_trace_id=None,
         direction=None,
         trace_ids=None,
-        entity_uid=None
+        entity_uid=None,
+        query=None
     ))]
     pub fn new(
         start_time: Option<DateTime<Utc>>,
@@ -240,6 +244,7 @@ impl TraceFilters {
         direction: Option<String>,
         trace_ids: Option<Vec<String>>,
         entity_uid: Option<String>,
+        query: Option<String>,
     ) -> Self {
         TraceFilters {
             clause: None,
@@ -251,6 +256,7 @@ impl TraceFilters {
             direction,
             trace_ids,
             entity_uid,
+            query,
         }
     }
 

--- a/py-scouter/python/scouter/_scouter.pyi
+++ b/py-scouter/python/scouter/_scouter.pyi
@@ -10088,6 +10088,7 @@ class TraceFilters:
     direction: Optional[str]
     trace_ids: Optional[List[str]]
     entity_uid: Optional[str]
+    query: Optional[str]
 
     def __init__(
         self,
@@ -10099,6 +10100,7 @@ class TraceFilters:
         direction: Optional[str] = None,
         trace_ids: Optional[List[str]] = None,
         entity_uid: Optional[str] = None,
+        query: Optional[str] = None,
     ) -> None:
         """Initialize trace filters.
 
@@ -10119,6 +10121,8 @@ class TraceFilters:
                 List of trace IDs to filter by
             entity_uid:
                 Filter by associated entity UID
+            query:
+                Optional trace search DSL query to parse into trace filters
         """
 
     @classmethod

--- a/py-scouter/python/scouter/stubs/tracing.pyi
+++ b/py-scouter/python/scouter/stubs/tracing.pyi
@@ -88,6 +88,7 @@ class TraceFilters:
     direction: Optional[str]
     trace_ids: Optional[List[str]]
     entity_uid: Optional[str]
+    query: Optional[str]
 
     def __init__(
         self,
@@ -99,6 +100,7 @@ class TraceFilters:
         direction: Optional[str] = None,
         trace_ids: Optional[List[str]] = None,
         entity_uid: Optional[str] = None,
+        query: Optional[str] = None,
     ) -> None:
         """Initialize trace filters.
 
@@ -119,6 +121,8 @@ class TraceFilters:
                 List of trace IDs to filter by
             entity_uid:
                 Filter by associated entity UID
+            query:
+                Optional trace search DSL query to parse into trace filters
         """
 
     @classmethod

--- a/py-scouter/tests/integration/test_trace_filters.py
+++ b/py-scouter/tests/integration/test_trace_filters.py
@@ -21,6 +21,12 @@ def test_quoted_service_key_remains_attribute_clause() -> None:
     }
 
 
+def test_trace_filters_accepts_body_query() -> None:
+    filters = TraceFilters(query="service:checkout")
+
+    assert filters.query == "service:checkout"
+
+
 def test_trace_metrics_request_round_trips_clause() -> None:
     now = datetime.now(timezone.utc)
     request = TraceMetricsRequest.from_query(


### PR DESCRIPTION
## Pull Request

### Short Summary

Moves the Lucene-style search query (`q`) from a URL query parameter into `TraceFilters` as a first-class `query: Option<String>` field. All three trace endpoints (`/paginated`, `/facets`, `/spans/filters`) previously accepted `?q=<dsl>` alongside a JSON body — now the DSL string travels in the body with everything else.

### Context

The old design split search state across two transport mechanisms: structured filters in the POST body, freetext DSL in the URL. That meant the server needed a dedicated `SearchQ` extractor, a `merge_q_into_filters` function to stitch them together, and the client had to parse the query string, then mutate the resulting struct field-by-field to apply overrides. It was fiddly and the URL param was invisible to any caller building `TraceFilters` directly.

**Before:**

```rust
// client: parse DSL, then override each field manually
let mut filters = TraceFilters::parse(q)?;
if let Some(start_time) = start_time { filters.start_time = Some(start_time); }
// ... 5 more fields

// server: separate extractor, then merge
async fn paginated_traces(
    Query(search): Query<SearchQ>,
    Json(body): Json<TraceFilters>,
) -> ... {
    let body = merge_q_into_filters(search.q, body)?;
```

**After:**

```rust
// client: struct literal, query is just another field
let filters = TraceFilters {
    query: Some(q.to_string()),
    start_time,
    end_time,
    ..Default::default()
};

// server: single extractor, normalize in place
async fn paginated_traces(
    Json(body): Json<TraceFilters>,
) -> ... {
    let body = normalize_trace_filters(body)?;
```

`normalize_trace_filters` reads `body.query`, parses it into a `FilterClause`, merges parsed fields into the body (body fields win on conflict), then clears `query` before passing the struct downstream. The DSL query field is consumed at the boundary — nothing downstream sees it.

Python stubs and PyO3 bindings updated to expose `query` on `TraceFilters.__init__`.

| File | Change |
|---|---|
| `crates/scouter_types/src/trace/sql.rs` | Adds `query: Option<String>` field to `TraceFilters` |
| `crates/scouter_server/src/api/routes/trace/route.rs` | Removes `SearchQ`, `?q=` params, renames merge fn to `normalize_trace_filters` |
| `crates/scouter_client/src/http/client.rs` | Replaces parse-then-mutate with struct literal |
| `crates/scouter_server/tests/api/trace.rs` | Updates tests to set `query` in body, removes URL helper |
| `py-scouter/python/scouter/_scouter.pyi` | Adds `query` param to `TraceFilters` stub |
| `py-scouter/python/scouter/stubs/tracing.pyi` | Same |
| `py-scouter/tests/integration/test_trace_filters.py` | Adds round-trip test for `query` field |

### Is this a Breaking Change?

Yes. The `?q=` query parameter is removed from all three trace endpoints. Any caller passing `?q=<dsl>` directly to the HTTP API must move the DSL string into the request body as `"query": "<dsl>"`.
